### PR TITLE
add filter category select

### DIFF
--- a/hbg-event-importer.php
+++ b/hbg-event-importer.php
@@ -74,6 +74,7 @@ $acfExportManager->autoExport(array(
     'recommendation' => 'group_5b15284158289',
     'under-processing' => 'group_5b2b60ac1bb08',
     'open-library-solutions' => 'group_5ce25720a2508',
+    'organization' => 'group_5ef1b6d006a4f',
 ));
 $acfExportManager->import();
 

--- a/source/php/AcfFields/json/organization.json
+++ b/source/php/AcfFields/json/organization.json
@@ -1,0 +1,53 @@
+[{
+    "key": "group_5ef1b6d006a4f",
+    "title": "Organisation",
+    "fields": [
+        {
+            "key": "field_5ef1b6db26521",
+            "label": "Organisation",
+            "name": "organisation",
+            "type": "taxonomy",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "taxonomy": "user_groups",
+            "field_type": "multi_select",
+            "allow_null": 1,
+            "add_term": 0,
+            "save_terms": 0,
+            "load_terms": 0,
+            "return_format": "id",
+            "multiple": 0
+        }
+    ],
+    "location": [
+        [
+            {
+                "param": "user_role",
+                "operator": "==",
+                "value": "all"
+            }
+        ],
+        [
+            {
+                "param": "taxonomy",
+                "operator": "==",
+                "value": "guidegroup"
+            }
+        ]
+    ],
+    "menu_order": 0,
+    "position": "normal",
+    "style": "default",
+    "label_placement": "top",
+    "instruction_placement": "label",
+    "hide_on_screen": "",
+    "active": true,
+    "description": ""
+}]
+

--- a/source/php/AcfFields/php/organization.php
+++ b/source/php/AcfFields/php/organization.php
@@ -1,0 +1,56 @@
+<?php 
+
+if (function_exists('acf_add_local_field_group')) {
+    acf_add_local_field_group(array(
+    'key' => 'group_5ef1b6d006a4f',
+    'title' => __('Organisation', 'event-manager'),
+    'fields' => array(
+        0 => array(
+            'key' => 'field_5ef1b6db26521',
+            'label' => __('Organisation', 'event-manager'),
+            'name' => 'organisation',
+            'type' => 'taxonomy',
+            'instructions' => '',
+            'required' => 0,
+            'conditional_logic' => 0,
+            'wrapper' => array(
+                'width' => '',
+                'class' => '',
+                'id' => '',
+            ),
+            'taxonomy' => 'user_groups',
+            'field_type' => 'multi_select',
+            'allow_null' => 1,
+            'add_term' => 0,
+            'save_terms' => 0,
+            'load_terms' => 0,
+            'return_format' => 'id',
+            'multiple' => 0,
+        ),
+    ),
+    'location' => array(
+        0 => array(
+            0 => array(
+                'param' => 'user_role',
+                'operator' => '==',
+                'value' => 'all',
+            ),
+        ),
+        1 => array(
+            0 => array(
+                'param' => 'taxonomy',
+                'operator' => '==',
+                'value' => 'guidegroup',
+            ),
+        ),
+    ),
+    'menu_order' => 0,
+    'position' => 'normal',
+    'style' => 'default',
+    'label_placement' => 'top',
+    'instruction_placement' => 'label',
+    'hide_on_screen' => '',
+    'active' => true,
+    'description' => '',
+));
+}

--- a/source/php/App.php
+++ b/source/php/App.php
@@ -88,6 +88,7 @@ class App
         new Api\PointPropertyFields();
         new Api\NavigationFields();
         new Api\RecommendationFields();
+        new Roles\EventEditor();
     }
 
     /**

--- a/source/php/Roles/EventEditor.php
+++ b/source/php/Roles/EventEditor.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace HbgEventImporter\Roles;
+
+class EventEditor
+{
+    private $role = 'guide_editor';
+
+    public function __construct()
+    {
+        add_filter('acf/fields/taxonomy/query', array($this, 'limitOptionsToUserOrganisations'), 10, 2);
+    }
+
+    public function limitOptionsToUserOrganisations($args, $field)
+    {
+        $user = get_user_by('id', get_current_user_id());
+        $userOrganisations = get_field('organisation', 'user_' . $user->ID);
+
+        if (
+            !in_array($this->role, $user->roles)
+            || empty($userOrganisations)
+            || $field['key'] !== 'field_589dd138aca7e'
+        ) {
+            return $args;
+        }
+
+        $args['meta_query'] = [
+            ['relation' => 'OR',
+                [
+                    'key' => 'organisation',
+                    'value' => $userOrganisations,
+                    'compare' => 'LIKE',
+                ],
+                [
+                    'key' => 'organisation',
+                    'compare' => 'NOT EXISTS',
+                ],
+            ]
+        ];
+
+        $args['hide_empty'] = false;
+
+        return $args;
+    }
+}


### PR DESCRIPTION
Categories colud not be filtered by user groups. Could confuse the guide editors upon selecting categories for a new or existing guide.

Now the selection of guide groups is filtered by the user group that a user is in. Categories that are not tagged to a group will always display amongst the selection option.