### PR TITLE
Merge events and update when changed

### DIFF
--- a/source/php/Entity/PostManager.php
+++ b/source/php/Entity/PostManager.php
@@ -220,9 +220,18 @@ abstract class PostManager
             }
         }
 
-        // Make sure to update if title changed
-        if (isset($data['post_type']) && $data['post_type'] == 'event' && isset($data['post_title'])) {
-            return get_the_title($postId) != $data['post_title'];
+        // Make sure to update if title or content is changed
+        if ( isset( $data[ 'post_type' ] ) && $data[ 'post_type' ] == 'event' )
+        {
+            $post = get_post( $postId );
+            if ( isset( $data[ 'post_title' ] ) && $post->post_title != $data[ 'post_title' ] )
+            {
+                return true;
+            }
+            if ( isset( $data[ 'post_content' ] ) && $post->post_content != $data[ 'post_content' ] )
+            {
+                return true;
+            }
         }
 
         // Compare old hashed post data with the new

--- a/source/php/Parser/TransTicket.php
+++ b/source/php/Parser/TransTicket.php
@@ -210,23 +210,7 @@ class TransTicket extends \HbgEventImporter\Parser
      */
     public function maybeCreateEvent($data, $shortKey, $locationId)
     {
-        $event_uid_key = 'transticket-' . $shortKey . '-' . $data['uId'];
-        $args = array(
-            'post_type' => 'event',
-            'meta_query' => array(
-                array(
-                    'key' => '_event_manager_uid',
-                    'value' => $event_uid_key
-                )
-            )
-        );
-
-        $query = new \WP_Query($args);
-        if( $query->have_posts() ) {
-            $eventId = $query->posts[0]->ID;
-        } else {
-            $eventId = null;
-        }
+        $eventId = $this->checkIfPostExists('event', $data['postTitle']);
         
         $occurred = false;
 


### PR DESCRIPTION
- Merges events correctly based on title. NOTE! Will need manual removal of previously duplicated events.
- Update events when title or extended description is changed

