### PR TITLE
Fix post title matching

### DIFF
--- a/source/php/Parser.php
+++ b/source/php/Parser.php
@@ -79,7 +79,10 @@ abstract class Parser
     public function checkIfPostExists($postType, $postTitle)
     {
         foreach ($this->levenshteinTitles[$postType] as $title) {
-            if ($this->isSimilarEnough(trim(html_entity_decode($postTitle)), $title['post_title'], $postType == 'location' ? 1 : 3)) {
+            if ($this->isSimilarEnough(
+                trim(html_entity_decode($postTitle)), 
+                trim(html_entity_decode($title['post_title'])), 
+                $postType == 'location' ? 1 : 3)) {
                 return $title['ID'];
             }
         }


### PR DESCRIPTION
Post title matching sometimes failed when title contains characters like ampersand (&) which will get HTML encoded when populating the levenshtein titles list causing titles to mismatch.