### PR TITLE
fix: enable title & editor

### DIFF
--- a/source/php/PostTypes/Event.php
+++ b/source/php/PostTypes/Event.php
@@ -20,7 +20,7 @@ class Event extends PostType
             'menu_icon'             => (new Icon('Event'))->getIcon(),
             'rest_base'             => 'events',
             'rest_controller_class' => \EventManager\RestControllers\EventController::class,
-            'supports'              => [ 'revisions' ],
+            'supports'              => ['title', 'editor', 'revisions'],
             'capability_type'       => ['event', 'events'],
         ];
     }


### PR DESCRIPTION
This needs to be enabled, to allow post titles to be entered from the frontend form. Giving the posts a name and content. 