### PR TITLE
fix: tags not created from content

### DIFF
--- a/api-event-manager.php
+++ b/api-event-manager.php
@@ -53,6 +53,7 @@ $app = new App(
 
 $app->loadPluginTextDomain();
 $app->setupAcfExportManager();
+$app->preventAcfFieldGroupToHideTheContentEditor();
 $app->setupPluginSettingsPage();
 $app->setupCleanupUnusedTags();
 $app->setPostTermsFromPostContent();

--- a/source/php/App.php
+++ b/source/php/App.php
@@ -42,6 +42,12 @@ class App
         $this->hooksRegistrar->register($acfExportManager);
     }
 
+    public function preventAcfFieldGroupToHideTheContentEditor(): void
+    {
+        $preventAcfFieldGroupToHideTheContentEditor = new \EventManager\Modifiers\PreventAcfFieldGroupToHideTheContentEditor('event', $this->wpService);
+        $this->hooksRegistrar->register($preventAcfFieldGroupToHideTheContentEditor);
+    }
+
     public function setupPluginSettingsPage(): void
     {
         $adminSettingsPage = new \EventManager\Settings\AdminSettingsPage($this->wpService, $this->acfService);

--- a/source/php/App.test.php
+++ b/source/php/App.test.php
@@ -5,9 +5,9 @@ namespace EventManager;
 use AcfService\AcfService;
 use EventManager\CronScheduler\CronSchedulerInterface;
 use EventManager\HooksRegistrar\HooksRegistrarInterface;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use WpService\WpService;
+use WpService\Implementations\FakeWpService;
 
 class AppTest extends TestCase
 {
@@ -29,7 +29,7 @@ class AppTest extends TestCase
     {
         $app = new App(
             'textdomain',
-            $this->createMock(WpService::class),
+            $this->getWpService(),
             $this->createMock(AcfService::class),
             $this->createMock(HooksRegistrarInterface::class),
             $this->createMock(CronSchedulerInterface::class)
@@ -40,8 +40,9 @@ class AppTest extends TestCase
 
     /**
      * @testdox all functions can be run without crashing
+     * @dataProvider provideAllFunctions
      */
-    public function testAllFunctions()
+    public function testAllFunctions(string $method)
     {
         $app = new App(
             'textdomain',
@@ -51,22 +52,32 @@ class AppTest extends TestCase
             $this->createMock(CronSchedulerInterface::class)
         );
 
-        foreach (get_class_methods(App::class) as $method) {
-            if ($method === '__construct') {
-                continue;
-            }
-
-            $app->$method();
-        }
+        $app->$method();
 
         $this->assertTrue(true);
     }
 
-    private function getWpService(): WpService|MockObject
+    public function provideAllFunctions(): array
     {
-        $mock = $this->createMock(WpService::class);
-        $mock->method('__')->willReturnArgument(0);
+        $appClass = App::class;
+        $methods  = get_class_methods(App::class);
+        $methods  = array_filter($methods, fn ($method) => $method !== '__construct');
 
-        return $mock;
+        $providedMethods = [];
+
+        foreach ($methods as $method) {
+            $providedMethods["{$appClass}::{$method}()"] = [$method];
+        }
+
+        return $providedMethods;
+    }
+
+    private function getWpService(): WpService
+    {
+        return new FakeWpService([
+            'addAction' => true,
+            'addFilter' => true,
+            '__'        => fn (string $text): string => $text,
+        ]);
     }
 }

--- a/source/php/Modifiers/PreventAcfFieldGroupToHideTheContentEditor.php
+++ b/source/php/Modifiers/PreventAcfFieldGroupToHideTheContentEditor.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace EventManager\Modifiers;
+
+use EventManager\HooksRegistrar\Hookable;
+use WpService\Contracts\AddFilter;
+use WpService\Contracts\GetPostType;
+use WpService\Contracts\IsAdmin;
+
+class PreventAcfFieldGroupToHideTheContentEditor implements Hookable
+{
+    public function __construct(private string $postType, private AddFilter&IsAdmin&GetPostType $wpService)
+    {
+    }
+    public function addHooks(): void
+    {
+        $this->wpService->addFilter('acf/load_field_group', [$this, 'preventAcfFieldGroupToHideTheContentEditor']);
+    }
+
+    public function preventAcfFieldGroupToHideTheContentEditor(array $fieldGroup): array
+    {
+        // if is edit screen of post type event
+        if (!$this->shouldRemoveHideOnScreen($fieldGroup)) {
+            return $fieldGroup;
+        }
+
+        return $this->removeTheContentFromHideOnScreen($fieldGroup);
+    }
+
+    private function removeTheContentFromHideOnScreen(array $fieldGroup): array
+    {
+        $hideOnScreen = array_filter($fieldGroup['hide_on_screen'], fn ($value) => $value !== 'the_content');
+
+        return [...$fieldGroup, 'hide_on_screen' => $hideOnScreen];
+    }
+
+    private function shouldRemoveHideOnScreen(array $fieldGroup): bool
+    {
+        if (!$this->isEventEditScreen()) {
+            return false;
+        }
+
+        if (!isset($fieldGroup['hide_on_screen']) || !is_array($fieldGroup['hide_on_screen'])) {
+            return false;
+        }
+
+        return in_array('the_content', $fieldGroup['hide_on_screen'], true);
+    }
+
+    private function isEventEditScreen(): bool
+    {
+        if (!$this->wpService->isAdmin() || !isset($_GET['post'])) {
+            return false;
+        }
+
+        return $this->wpService->getPostType($_GET['post']) === $this->postType;
+    }
+}

--- a/source/php/Modifiers/PreventAcfFieldGroupToHideTheContentEditorTest.php
+++ b/source/php/Modifiers/PreventAcfFieldGroupToHideTheContentEditorTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace EventManager\Modifiers;
+
+use EventManager\HooksRegistrar\Hookable;
+use PHPUnit\Framework\TestCase;
+use WP_Post;
+use WpService\Contracts\AddFilter;
+use WpService\Contracts\GetPostType;
+use WpService\Contracts\IsAdmin;
+
+class PreventAcfFieldGroupToHideTheContentEditorTest extends TestCase
+{
+    /**
+     * @testdox can be instantiated
+     */
+    public function testCanBeInstantiated(): void
+    {
+        $wpService = static::createWpService();
+        $modifier  = new PreventAcfFieldGroupToHideTheContentEditor('event', $wpService);
+        $this->assertInstanceOf(PreventAcfFieldGroupToHideTheContentEditor::class, $modifier);
+    }
+
+    /**
+     * @testdox adds the correct filter hook
+     */
+    public function testAddsCorrectFilterHook(): void
+    {
+        $wpService = static::createWpService();
+        $modifier  = new PreventAcfFieldGroupToHideTheContentEditor('event', $wpService);
+        $modifier->addHooks();
+
+        $this->assertCount(1, $wpService->addedFilters);
+        $this->assertSame('acf/load_field_group', $wpService->addedFilters[0]['hookName']);
+        $this->assertSame([$modifier, 'preventAcfFieldGroupToHideTheContentEditor'], $wpService->addedFilters[0]['callback']);
+    }
+
+    /**
+     * @testdox does not modify field group if not on admin screen
+     */
+    public function testDoesNotModifyFieldGroupIfNotOnAdminScreen(): void
+    {
+        $wpService = static::createWpService(false);
+        $modifier  = new PreventAcfFieldGroupToHideTheContentEditor('event', $wpService);
+
+        $fieldGroup = [
+            'hide_on_screen' => ['the_content', 'other_field'],
+        ];
+
+        $result = $modifier->preventAcfFieldGroupToHideTheContentEditor($fieldGroup);
+
+        $this->assertSame($fieldGroup, $result);
+    }
+
+    /**
+     * @testdox does not modify field group if not on event edit screen
+     */
+    public function testDoesNotModifyFieldGroupIfNotOnEventEditScreen(): void
+    {
+        $_GET['post'] = 123; // Simulate being on a post edit screen
+        $wpService    = static::createWpService(true, 'post');
+        $modifier     = new PreventAcfFieldGroupToHideTheContentEditor('event', $wpService);
+
+        $fieldGroup = [
+            'hide_on_screen' => ['the_content', 'other_field'],
+        ];
+
+        $result = $modifier->preventAcfFieldGroupToHideTheContentEditor($fieldGroup);
+
+        $this->assertSame($fieldGroup, $result);
+    }
+
+    /**
+     * @testdox removes 'the_content' from hide_on_screen if on event edit screen
+     */
+    public function testRemovesTheContentFromHideOnScreenIfOnEventEditScreen(): void
+    {
+        $_GET['post'] = 123; // Simulate being on a post edit screen
+        $wpService    = static::createWpService(true, 'event');
+        $modifier     = new PreventAcfFieldGroupToHideTheContentEditor('event', $wpService);
+
+        $result = $modifier->preventAcfFieldGroupToHideTheContentEditor([
+            'hide_on_screen' => ['the_content', 'other_field'],
+        ]);
+
+        $this->assertNotContains('the_content', $result['hide_on_screen']);
+    }
+
+    private static function createWpService(bool $isAdmin = true, string $postType = 'event'): AddFilter&IsAdmin&GetPostType
+    {
+        return new class ($isAdmin, $postType) implements AddFilter, IsAdmin, GetPostType {
+            public array $addedFilters = [];
+
+            public function __construct(private bool $isAdmin, private string $postType)
+            {
+            }
+
+            public function addFilter(string $hookName, callable $callback, int $priority = 10, int $acceptedArgs = 1): true
+            {
+                $this->addedFilters[] = [
+                    'hookName'     => $hookName,
+                    'callback'     => $callback,
+                    'priority'     => $priority,
+                    'acceptedArgs' => $acceptedArgs,
+                ];
+
+                return true;
+            }
+
+            public function isAdmin(): bool
+            {
+                return $this->isAdmin;
+            }
+
+            public function getPostType(int|WP_Post|null $post = null): string|false
+            {
+                return $this->postType;
+            }
+        };
+    }
+}


### PR DESCRIPTION
The content field on event posts was hidden by acf field groups, so a modifier was added to prevent that from happening.